### PR TITLE
🚨 fix: 마이/유저 페이지 즉각적인 데이터 갱신

### DIFF
--- a/src/api/supabase/post.js
+++ b/src/api/supabase/post.js
@@ -1,5 +1,6 @@
 import { supabase } from '@/config/supabase';
 import { getPostComments } from '@/api/supabase/comment';
+import { getUserInfoToUserId } from './user';
 
 export const getAllPosts = async (filters, size = 10) => {
   try {
@@ -13,6 +14,88 @@ export const getAllPosts = async (filters, size = 10) => {
     console.error(error);
   }
 };
+
+// 특정 페이지의 게시물을 보여주는 API (1페이지당 12개 보여주기)
+// export const getAllPostsWithPagination = async (filters, page = 1, pageSize = 12) => {
+//   try {
+//     const from = (page - 1) * pageSize;
+//     const to = page * pageSize - 1;
+
+//     // 기술 스택 요소를 포함하는 post_id를 담을 배열
+//     let matchingPostIds = [];
+//     if (filters.techStack && filters.techStack.length > 0) {
+//       const { data: stackData } = await supabase
+//         .from('post_stacks')
+//         .select('post_id')
+//         .or(filters.techStack.map((tech) => `stack.ilike.%${tech}%`).join(','));
+
+//       matchingPostIds = stackData?.map((item) => item.post_id) || [];
+
+//       if (matchingPostIds.length === 0) {
+//         return { data: [], totalPost: 0, page, totalPage: 0 };
+//       }
+//     }
+
+//     // 쿼리 체이닝 방식을 사용시 await을 마지막에 단 한번 실행
+//     // post_positions 테이블을 post 테이블과 inner join
+//     let query = supabase
+//       .from('post')
+//       .select(`*,post_positions!inner(position)`, { count: 'exact' })
+//       .order('created_at', { ascending: false });
+
+//     if (matchingPostIds.length > 0) {
+//       query = query.in('id', matchingPostIds);
+//     }
+//     if (filters.position && filters.position !== '전체') {
+//       query = query.ilike('post_positions.position', `%${filters.position}%`);
+//     }
+//     if (filters.recruitArea && filters.recruitArea !== '전체') {
+//       query = query.ilike('recruit_area', `%${filters.recruitArea}%`); // 수정된 부분
+//     }
+//     if (filters.recruitType) {
+//       query = query.ilike('recruit_type', filters.recruitType);
+//     }
+//     if (filters.onOffline && filters.onOffline !== '전체') {
+//       query = query.ilike('on_offline', `%${filters.onOffline}%`); // 수정된 부분
+//     }
+//     //like, is 연산자는 문자열 비교에만 사용된다.
+//     //  boolean 타입은  eq로 비교해야한다.
+//     if (typeof filters.finished === 'boolean' && filters.finished) {
+//       query = query.eq('finished', filters.finished); // 수정된 부분
+//     }
+//     if (filters.searchResults) {
+//       query = query.or(`title.ilike.%${filters.searchResults}%`);
+//     }
+
+//     query = query.range(from, to);
+//     const { data, error, count } = await query; // 수정된 부분
+
+//     if (error) {
+//       throw new Error(error);
+//     }
+
+//     const totalPage = Math.ceil((count || 0) / pageSize);
+
+//     const totalData = await Promise.all(
+//       data.map(async (item) => {
+//         const userInfo = await getUserInfoToUserId(item.author);
+
+//         return {
+//           ...item,
+//           name: userInfo.name,
+//           profile_img_path: userInfo.profile_img_path,
+//           positions: await getPostPositions(item.id),
+//           techStacks: await getPostTechStacks(item.id),
+//         };
+//       }),
+//     );
+
+//     return { data: totalData, totalPost: count, page, totalPage };
+//   } catch (error) {
+//     console.error(error);
+//     return { data: [], totalPost: 0, page, totalPage: 0 };
+//   }
+// };
 
 export const getAllPostsWithPagination = async (filters, page = 1, page_size = 12) => {
   try {

--- a/src/api/supabase/post_editor.js
+++ b/src/api/supabase/post_editor.js
@@ -87,19 +87,18 @@ export const postUploadPostImage = async (file) => {
     }
     const encodedFileName = encodeURIComponent(file.name).replace(/%/g, '');
     const exist_files = await supabase.storage.from('post_images').list('');
-    let addData = true;
-    exist_files.data.map((e) => {
-      if (e.name === encodedFileName) {
-        addData = false;
-      }
-    });
-    if (addData) {
+
+    // 파일 존재 여부 확인
+    const fileExists = exist_files.data.some((e) => e.name === encodedFileName);
+
+    // 파일이 없다면 업로드
+    if (!fileExists) {
       const { error } = await supabase.storage.from('post_images').upload(encodedFileName, file, {
         cacheControl: '3600',
         upsert: false,
       });
       if (error) {
-        throw new Error(error);
+        throw new Error(error.message);
       }
     }
 

--- a/src/hooks/usePagination.js
+++ b/src/hooks/usePagination.js
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/vue-query';
 import { computed, ref, watch } from 'vue';
 
-export const usePagination = (fetchData, queryKey, filters = {}, enableCache = true) => {
+export const usePagination = (fetchData, queryKey, filters = {}) => {
   // 현재 페이지, 전체 페이지
   const currentPage = ref(1);
   const totalPage = computed(() => data?.value?.total_page || 1);
@@ -12,11 +12,12 @@ export const usePagination = (fetchData, queryKey, filters = {}, enableCache = t
   // 필터링
   const selectedFilter = ref(filters);
 
+  // queryKey가 currentPage와 selectedFilter를 반영하도록 업데이트
   const { isLoading, data, refetch } = useQuery({
     queryKey: [queryKey, selectedFilter.value, currentPage.value],
     queryFn: fetchData,
-    staleTime: enableCache ? 1000 * 60 * 5 : 0, // 유통기한
-    gcTime: enableCache ? 1000 * 60 * 5 : 0,
+    staleTime: 1000 * 60 * 5, // 유통기한
+    gcTime: 1000 * 60 * 5,
     structuralSharing: true, // 변경되지않은 데이터 재사용
     placeholderData: (prev) => prev, // 대기 상태때 표시해줄 데이터
   });
@@ -33,7 +34,7 @@ export const usePagination = (fetchData, queryKey, filters = {}, enableCache = t
     refetch();
   };
 
-  //  필터링 업데이트 함수
+  // 필터링 업데이트 함수
   const handleUpdateFilter = (newFilter) => {
     selectedFilter.value = { ...selectedFilter.value, ...newFilter };
   };
@@ -44,7 +45,6 @@ export const usePagination = (fetchData, queryKey, filters = {}, enableCache = t
     currentPage,
     totalPage,
     selectedFilter,
-    refetch,
     handleChangePage,
     handleUpdateFilter,
   };

--- a/src/pages/Mypage/MyPage.vue
+++ b/src/pages/Mypage/MyPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import TabMenu from '@/components/TabMenu.vue';
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 import MyInfo from './components/MyInfo.vue';
 import PositionSmallBadge from '@/components/PositionSmallBadge.vue';
 import MyRecruitmentList from './components/MyRecruitmentList.vue';
@@ -13,6 +13,9 @@ import LoadingPage from '../LoadingPage.vue';
 import { useUserStore } from '@/stores/user';
 import { storeToRefs } from 'pinia';
 import { successToast } from '@/utils/toast';
+import { useQueryClient } from '@tanstack/vue-query';
+
+const queryClient = useQueryClient();
 
 const items = ['내 정보', '작성한 모집글', '신청 목록', '찜 목록'];
 const activeIndex = ref(0);
@@ -27,6 +30,10 @@ const { user } = storeToRefs(userStore);
 const handleEditProfile = () => {
   router.push('/EditProfile');
 };
+
+watch(activeIndex, async () => {
+  await queryClient.invalidateQueries('filteredMyPosts');
+});
 
 onMounted(async () => {
   // 탭의 갯수보다 큰 index 임의 조작시 0으로 강제 전환

--- a/src/pages/Mypage/components/MyBookmark.vue
+++ b/src/pages/Mypage/components/MyBookmark.vue
@@ -34,14 +34,9 @@ const {
   selectedFilter,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(
-  fetchUserBookmarkWithPagination,
-  'filteredBookmarkPosts',
-  {
-    order: '최신순',
-  },
-  false,
-);
+} = usePagination(fetchUserBookmarkWithPagination, 'filteredBookmarkPosts', {
+  order: '최신순',
+});
 
 const handleSelectOrder = (order) => {
   handleUpdateFilter({ order });

--- a/src/pages/Mypage/components/MyRecruitmentList.vue
+++ b/src/pages/Mypage/components/MyRecruitmentList.vue
@@ -1,6 +1,5 @@
 <script setup>
 import PostCard from '@/components/PostCard.vue';
-import { onMounted } from 'vue';
 import { getPostsByUser } from '@/api/supabase/post';
 import { useRouter } from 'vue-router';
 import FilterDropdown from '@/components/FilterDropdown.vue';
@@ -11,15 +10,10 @@ import { storeToRefs } from 'pinia';
 import { usePagination } from '@/hooks/usePagination';
 
 const router = useRouter();
-
 const userStore = useUserStore();
 const { user } = storeToRefs(userStore);
 
 const orderFilterList = ['최신순', '오래된순', '인기순', '마감일순'];
-
-onMounted(() => {
-  fetchMyPostsWithPagination();
-});
 
 // 필터링 & 페이지네이션 처리된 게시물 불러오기
 const fetchMyPostsWithPagination = async () => {
@@ -41,14 +35,9 @@ const {
   selectedFilter,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(
-  fetchMyPostsWithPagination,
-  'filteredMyPosts',
-  {
-    order: '최신순',
-  },
-  false,
-);
+} = usePagination(fetchMyPostsWithPagination, 'filteredMyPosts', {
+  order: '최신순',
+});
 
 const handleSelectOrder = (order) => {
   handleUpdateFilter({ order });

--- a/src/pages/Mypage/components/MyRequestList.vue
+++ b/src/pages/Mypage/components/MyRequestList.vue
@@ -32,14 +32,9 @@ const {
   refetch,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(
-  fetchMyApplyPostsWithPagination,
-  'filteredApplyPosts',
-  {
-    status: '전체',
-  },
-  false,
-);
+} = usePagination(fetchMyApplyPostsWithPagination, 'filteredApplyPosts', {
+  status: '전체',
+});
 const handleGetStatus = (status) => {
   status = status === '전체' ? null : status;
   handleUpdateFilter({ status });

--- a/src/pages/UserPage/UserPage.vue
+++ b/src/pages/UserPage/UserPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import TabMenu from '@/components/TabMenu.vue';
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 import PositionSmallBadge from '@/components/PositionSmallBadge.vue';
 import { useRouter } from 'vue-router';
 import { getUserInfoToUserId } from '@/api/supabase/user';
@@ -11,6 +11,9 @@ import UserRecruitmentList from './components/UserRecruitmentList.vue';
 import { useUserStore } from '@/stores/user';
 import LoadingPage from '../LoadingPage.vue';
 import { storeToRefs } from 'pinia';
+import { useQueryClient } from '@tanstack/vue-query';
+
+const queryClient = useQueryClient();
 
 const items = ['유저 정보', '작성한 모집글', '후기/평가 목록'];
 const activeIndex = ref(0);
@@ -25,6 +28,10 @@ const userId = useRoute().params.userId;
 // 현재 로그인한 사용자(나)
 const userStore = useUserStore();
 const { user } = storeToRefs(userStore);
+
+watch(activeIndex, async () => {
+  await queryClient.invalidateQueries('filteredMyPosts');
+});
 
 onMounted(async () => {
   fetchUserinfo();

--- a/src/pages/UserPage/components/UserRecruitmentList.vue
+++ b/src/pages/UserPage/components/UserRecruitmentList.vue
@@ -48,14 +48,9 @@ const {
   selectedFilter,
   handleChangePage,
   handleUpdateFilter,
-} = usePagination(
-  fetchUserPostsWithPagination,
-  'filteredUserPosts',
-  {
-    order: '최신순',
-  },
-  false,
-);
+} = usePagination(fetchUserPostsWithPagination, 'filteredUserPosts', {
+  order: '최신순',
+});
 
 const handleSelectOrder = (order) => {
   handleUpdateFilter({ order });


### PR DESCRIPTION
## 🪄 변경 사항
- [x] myPage, userPage에 watch 함수를 사용해 activeIndex가 바뀔때다 쿼리 무효화하고 해당 탭의 데이터가 즉시 갱신
## 💡 반영 브랜치

## 🖼️ 결과 화면 (생략 가능)

## 💬 리뷰어에게 전할 말
